### PR TITLE
feat: Add release drafter workflow for automated release notes genera…

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES
+
+categories:
+  - title: "🚀 Features"
+    label: "feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,18 @@ on:
     branches: [main]
 
 jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION

This pull request includes changes to automate the release drafting process using GitHub Actions. The most important changes include adding a release drafter template and configuring a workflow to update the release draft when a pull request is merged.

Release drafting automation:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR1-R13): Added a template for release notes and categorized changes into "Features" and "Bug Fixes".

Workflow configuration:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR9-R20): Configured a new job `update_release_draft` to run when a pull request is merged, using the `release-drafter` action to update the release draft.