### PR TITLE
fix: Update Dockerfile to use Bun for package management and build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get package version
         id: package_version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM node:23.7-alpine3.21
+FROM oven/bun:1.1.45-alpine
 
 ENV REQUEST_TIMEOUT=30000
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
+COPY package.json bun.lockb ./
 
-RUN yarn install
+RUN bun install
 
 COPY . .
 
-RUN yarn build
+RUN bun run build
 
 # Expor CLI helper
-RUN echo '#!/bin/sh\nnode /app/dist/merge-cli.js "$@"' > /usr/local/bin/merge-pdf && \
+RUN echo '#!/bin/sh\nbun /app/dist/merge-cli.js "$@"' > /usr/local/bin/merge-pdf && \
     chmod +x /usr/local/bin/merge-pdf
 
 EXPOSE 3000
 
-CMD ["yarn", "serve"] 
+CMD ["bun", "run", "serve"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated Docker image to Bun runtime, replacing Node/Yarn. Build, serve, and CLI execution now use Bun.
- Chores
  - Updated CI workflow to read package version using jq with no change to release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->